### PR TITLE
feat: improve AEO score with sitemap, JSON-LD, and project detail routes

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -1,36 +1,13 @@
 import FadeIn from './FadeIn';
 import LottieAnimation from './LottieAnimation';
 import HoverThumbnail from './HoverThumbnail';
+import Nav from './Nav';
 
 export default function Header() {
 
   return (
     <>
-      <FadeIn position="down" className="w-full max-w-[1440px] flex items-center justify-between py-4 px-4 lg:px-20 t-0 absolute">
-        <svg className='text-zinc-950 dark:text-zinc-50' id="logo" width="58" height="40" viewBox="0 0 58 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d='M1 36C5.27925 30.0845 23 9.95764 18.6834 9.97834C14.3668 9.99904 2.16421 36 11.6037 36C19.1239 36 26.707 12.3068 29.3501 5.95081'
-            fill='none'
-            stroke='currentColor'
-            strokeWidth='2'
-            strokeLinecap='round'
-          />
-          <path
-            d='M39.9552 13.5873C38.5025 21.0603 34.3544 35.9905 29.2256 35.9905C22.8067 35.9905 25.0407 7.48312 44.4233 4.30513C60.0299 1.75648 62.7674 15.727 29.0683 25.607'
-            fill='none'
-            stroke='currentColor'
-            strokeWidth='2'
-            strokeLinecap='round'
-          />
-        </svg>
-
-        <a href='mailto:mail@niklaspeterson.com?subject=Contact' className='px-5 py-3 text-base btn-primary' aria-label='Contact'>
-          <span className='mx-1'>Contact</span>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-5 h-5">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
-          </svg>
-        </a>
-      </FadeIn>
+      <Nav className="t-0 absolute" />
 
       <FadeIn position="down" className='flex flex-col justify-center gap-4 px-4 max-w-5xl h-[560px] sm:h-[640px] lg:px-20 md:py-32 md:h-[720px]'>
         <div className="absolute top-0 left-0 right-0 -z-10 blur-[120px] max-w-full overflow-hidden flex justify-center"><LottieAnimation /></div>

--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import FadeIn from './FadeIn';
+
+export default function Nav({ className = '' }) {
+  return (
+    <FadeIn
+      position="down"
+      className={`w-full max-w-[1440px] flex items-center justify-between py-4 px-4 lg:px-20 ${className}`}
+    >
+      <Link href="/" aria-label="Niklas Peterson — home">
+        <svg
+          className="text-zinc-950 dark:text-zinc-50"
+          id="logo"
+          width="58"
+          height="40"
+          viewBox="0 0 58 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 36C5.27925 30.0845 23 9.95764 18.6834 9.97834C14.3668 9.99904 2.16421 36 11.6037 36C19.1239 36 26.707 12.3068 29.3501 5.95081"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+          <path
+            d="M39.9552 13.5873C38.5025 21.0603 34.3544 35.9905 29.2256 35.9905C22.8067 35.9905 25.0407 7.48312 44.4233 4.30513C60.0299 1.75648 62.7674 15.727 29.0683 25.607"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      </Link>
+
+      <a
+        href="mailto:mail@niklaspeterson.com?subject=Contact"
+        className="px-5 py-3 text-base btn-primary"
+        aria-label="Contact"
+      >
+        <span className="mx-1">Contact</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="1.5"
+          stroke="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z"
+          />
+        </svg>
+      </a>
+    </FadeIn>
+  );
+}

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -76,7 +76,7 @@ export default function Projects({ projects = [] }) {
                 <div key={i} className="relative md:snap-center">
                   {attachment.type === 'image' ? (
                       <Image
-                        className="rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]"
+                        className="rounded-lg w-auto h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]"
                         src={attachment.url}
                         alt={attachment.alt}
                         height={attachment.height}
@@ -84,7 +84,7 @@ export default function Projects({ projects = [] }) {
                       />
                   ) : (
                     <video
-                      className="rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]"
+                      className="rounded-lg w-auto h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]"
                       src={attachment.url}
                       height={attachment.height}
                       width={attachment.width}

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -71,34 +71,45 @@ export default function Projects({ projects = [] }) {
               </div>
             </div>
 
-            <div className={`flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory`}>
-              {selectedProject.attachments.map((attachment, i) => (
-                <div key={i} className="relative md:snap-center">
-                  {attachment.type === 'image' ? (
-                      <Image
-                        className="rounded-lg w-auto h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]"
-                        src={attachment.url}
-                        alt={attachment.alt}
-                        height={attachment.height}
-                        width={attachment.width}
-                      />
-                  ) : (
-                    <video
-                      className="rounded-lg w-auto h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]"
-                      src={attachment.url}
-                      height={attachment.height}
-                      width={attachment.width}
-                      autoPlay
-                      muted
-                      loop
-                      playsInline
+            {(() => {
+              const isSingle = selectedProject.attachments.length === 1;
+              const galleryClass = isSingle
+                ? "flex flex-col px-4 md:px-10 pb-5 md:pb-8 animate-fadeUp"
+                : "flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory";
+              const itemClass = isSingle ? "relative w-full" : "relative md:snap-center";
+              const mediaClass = isSingle
+                ? "rounded-lg w-full h-auto"
+                : "rounded-lg w-auto h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
 
-                    />
-                  )}
+              return (
+                <div className={galleryClass}>
+                  {selectedProject.attachments.map((attachment, i) => (
+                    <div key={i} className={itemClass}>
+                      {attachment.type === 'image' ? (
+                          <Image
+                            className={mediaClass}
+                            src={attachment.url}
+                            alt={attachment.alt}
+                            height={attachment.height}
+                            width={attachment.width}
+                          />
+                      ) : (
+                        <video
+                          className={mediaClass}
+                          src={attachment.url}
+                          height={attachment.height}
+                          width={attachment.width}
+                          autoPlay
+                          muted
+                          loop
+                          playsInline
+                        />
+                      )}
+                    </div>
+                  ))}
                 </div>
-              ))}
-
-            </div>
+              );
+            })()}
           </div>
         </div>
       )}

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -1,24 +1,12 @@
 "use client"
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import FadeIn from './FadeIn';
 
-export default function Projects() {
-  const [selectedProject, setSelectedProject] = useState(null); // State to hold the selected project
-  const [projects, setProjects] = useState([]); // State to hold the projects
-
-  // Fetch projects from the JSON file
-  useEffect(() => {
-    const fetchProjects = async () => {
-      const response = await fetch('/projects.json'); // Adjust the path as necessary
-      const data = await response.json();
-      // Combine collections and filter projects with attachments
-      let projects = data.filter(x => x.attachments.length > 0);
-      setProjects(projects);
-    };
-    fetchProjects();
-  }, []);
+export default function Projects({ projects = [] }) {
+  const [selectedProject, setSelectedProject] = useState(null);
 
   const openProject = (project) => {
     setSelectedProject(project);
@@ -35,7 +23,7 @@ export default function Projects() {
         if (project.attachments.length < 1) { return null; }
 
         return (
-          <FadeIn key={index} className="flex flex-col md:flex-[1_1_40%]" index={index} >
+          <FadeIn key={project.slug ?? index} className="flex flex-col md:flex-[1_1_40%]" index={index} >
             <ProjectContent project={project} onOpen={openProject} priority={index < 2} />
           </FadeIn>
         )
@@ -65,7 +53,7 @@ export default function Projects() {
                     {selectedProject.year && <div>Company:</div>}
                     {selectedProject.year && <div>Date:</div>}
                     {selectedProject.url && <div>Link:</div>}
-                    {/* {selectedProject.title == "Musho" && <div style={{ display: "none" }}>Case study:</div>} */}
+                    {selectedProject.slug && <div>Case study:</div>}
                   </div>
 
                   <div className="flex flex-col gap-4">
@@ -78,13 +66,13 @@ export default function Projects() {
                       </span>
                     </a>
                     }
-                    {/* {selectedProject.title == "Musho" && <a style={{ display: "none" }} href="https://cv.niklaspeterson.com/musho" target="_blank">
+                    {selectedProject.slug && <Link className="btn-link" href={`/projects/${selectedProject.slug}`}>
                       <span className="flex gap-1 items-center">
-                        Visit
+                        Read more
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-4 h-4"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"></path></svg>
                       </span>
-                    </a>
-                    } */}
+                    </Link>
+                    }
                   </div>
 
                 </div>
@@ -127,11 +115,17 @@ export default function Projects() {
 }
 
 function ProjectContent({ project, onOpen, priority }) {
+  const handleClick = (e) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+    e.preventDefault();
+    onOpen(project);
+  };
+
   return (
-    <button
-      type="button"
+    <Link
+      href={`/projects/${project.slug}`}
       className="group flex h-full w-full cursor-pointer flex-col gap-5 text-left"
-      onClick={() => onOpen(project)}
+      onClick={handleClick}
       aria-label={`Open ${project.title} project`}
     >
       {project.attachments.map((media, index) => {
@@ -156,8 +150,8 @@ function ProjectContent({ project, onOpen, priority }) {
         <div className="text-md md:text-lg line-clamp-2">
           {project.description}
         </div>
-        
+
       </div>
-    </button>
+    </Link>
   );
 }

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -53,7 +53,6 @@ export default function Projects({ projects = [] }) {
                     {selectedProject.year && <div>Company:</div>}
                     {selectedProject.year && <div>Date:</div>}
                     {selectedProject.url && <div>Link:</div>}
-                    {selectedProject.slug && <div>Case study:</div>}
                   </div>
 
                   <div className="flex flex-col gap-4">
@@ -65,13 +64,6 @@ export default function Projects({ projects = [] }) {
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-4 h-4"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"></path></svg>
                       </span>
                     </a>
-                    }
-                    {selectedProject.slug && <Link className="btn-link" href={`/projects/${selectedProject.slug}`}>
-                      <span className="flex gap-1 items-center">
-                        Read more
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-4 h-4"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"></path></svg>
-                      </span>
-                    </Link>
                     }
                   </div>
 

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -73,14 +73,13 @@ export default function Projects({ projects = [] }) {
 
             {(() => {
               const isSingle = selectedProject.attachments.length === 1;
-              const galleryClass = "flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory";
               const itemClass = isSingle ? "relative md:w-full" : "relative md:snap-center";
               const mediaClass = isSingle
-                ? "rounded-lg w-auto max-w-[calc(100vw-32px)] max-h-[600px] md:w-full md:h-auto md:max-w-full md:max-h-none"
-                : "rounded-lg w-auto max-w-[calc(100vw-32px)] max-h-[600px] md:max-w-[80vw] md:h-[60vh]";
+                ? "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
+                : "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
 
               return (
-                <div className={galleryClass}>
+                <div className="flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory">
                   {selectedProject.attachments.map((attachment, i) => (
                     <div key={i} className={itemClass}>
                       {attachment.type === 'image' ? (

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -73,13 +73,11 @@ export default function Projects({ projects = [] }) {
 
             {(() => {
               const isSingle = selectedProject.attachments.length === 1;
-              const galleryClass = isSingle
-                ? "flex flex-col px-4 md:px-10 pb-5 md:pb-8 animate-fadeUp"
-                : "flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory";
-              const itemClass = isSingle ? "relative w-full" : "relative md:snap-center";
+              const galleryClass = "flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory";
+              const itemClass = isSingle ? "relative md:w-full" : "relative md:snap-center";
               const mediaClass = isSingle
-                ? "rounded-lg w-full h-auto"
-                : "rounded-lg w-auto h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
+                ? "rounded-lg w-auto max-w-[calc(100vw-32px)] max-h-[600px] md:w-full md:h-auto md:max-w-full md:max-h-none"
+                : "rounded-lg w-auto max-w-[calc(100vw-32px)] max-h-[600px] md:max-w-[80vw] md:h-[60vh]";
 
               return (
                 <div className={galleryClass}>

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -19,15 +19,11 @@ export default function Projects({ projects = [] }) {
   return (
     <>
     <div className='flex flex-wrap gap-12 px-4 pb-20 lg:px-20 md:pb-32'>
-      {projects.map((project, index) => {
-        if (project.attachments.length < 1) { return null; }
-
-        return (
-          <FadeIn key={project.slug ?? index} className="flex flex-col md:flex-[1_1_40%]" index={index} >
-            <ProjectContent project={project} onOpen={openProject} priority={index < 2} />
-          </FadeIn>
-        )
-      })}
+      {projects.map((project, index) => (
+        <FadeIn key={project.slug ?? index} className="flex flex-col md:flex-[1_1_40%]" index={index} >
+          <ProjectContent project={project} onOpen={openProject} priority={index < 2} />
+        </FadeIn>
+      ))}
     </div>
 
     {selectedProject && (
@@ -71,46 +67,48 @@ export default function Projects({ projects = [] }) {
               </div>
             </div>
 
-            {(() => {
-              const isSingle = selectedProject.attachments.length === 1;
-              const itemClass = isSingle ? "relative md:w-full" : "relative md:snap-center";
-              const mediaClass = isSingle
-                ? "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
-                : "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
-
-              return (
-                <div className="flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory">
-                  {selectedProject.attachments.map((attachment, i) => (
-                    <div key={i} className={itemClass}>
-                      {attachment.type === 'image' ? (
-                          <Image
-                            className={mediaClass}
-                            src={attachment.url}
-                            alt={attachment.alt}
-                            height={attachment.height}
-                            width={attachment.width}
-                          />
-                      ) : (
-                        <video
-                          className={mediaClass}
-                          src={attachment.url}
-                          height={attachment.height}
-                          width={attachment.width}
-                          autoPlay
-                          muted
-                          loop
-                          playsInline
-                        />
-                      )}
-                    </div>
-                  ))}
-                </div>
-              );
-            })()}
+            <ModalGallery attachments={selectedProject.attachments} />
           </div>
         </div>
       )}
     </>
+  );
+}
+
+function ModalGallery({ attachments }) {
+  const isSingle = attachments.length === 1;
+  const itemClass = isSingle ? "relative md:w-full" : "relative md:snap-center";
+  const mediaClass = isSingle
+    ? "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
+    : "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
+
+  return (
+    <div className="flex flex-col md:flex-row px-4 md:px-10 pb-5 md:pb-8 gap-4 md:gap-6 items-center animate-fadeUp md:overflow-x-auto md:snap-x md:snap-mandatory">
+      {attachments.map((attachment, i) => (
+        <div key={i} className={itemClass}>
+          {attachment.type === 'image' ? (
+            <Image
+              className={mediaClass}
+              src={attachment.url}
+              alt={attachment.alt}
+              height={attachment.height}
+              width={attachment.width}
+            />
+          ) : (
+            <video
+              className={mediaClass}
+              src={attachment.url}
+              height={attachment.height}
+              width={attachment.width}
+              autoPlay
+              muted
+              loop
+              playsInline
+            />
+          )}
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -132,8 +130,8 @@ function ProjectContent({ project, onOpen, priority }) {
         if (index !== 0) return null;
 
         const attachment = media.type === "image"
-          ? <Image className="" width={media.width} height={media.height} src={media.url} alt={media.alt} priority={priority} />
-          : <video className="" src={media.url} autoPlay muted playsInline loop />;
+          ? <Image width={media.width} height={media.height} src={media.url} alt={media.alt} priority={priority} />
+          : <video src={media.url} autoPlay muted playsInline loop />;
 
         return (
           <div key={media.id || index} className="rounded-2xl md:rounded-3xl overflow-hidden relative w-full after:content-[''] after:absolute after:inset-0 after:border after:border-white/20 after:pointer-events-none after:rounded-2xl after:md:rounded-3xl transition-transform duration-200 shadow-none group-hover:scale-102 group-hover:shadow-lg active:scale-99">

--- a/app/layout.js
+++ b/app/layout.js
@@ -40,6 +40,21 @@ export default function RootLayout({ children }) {
     ],
   };
 
+  const organizationSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `${SITE_URL}/#organization`,
+    name: 'Niklas Peterson',
+    url: SITE_URL,
+    logo: `${SITE_URL}/niklas-peterson.jpg`,
+    founder: { '@id': `${SITE_URL}/#person` },
+    sameAs: [
+      'https://x.com/niklas_peterson',
+      'https://www.linkedin.com/in/niklaspeterson',
+      'https://www.figma.com/@niklaspeterson',
+    ],
+  };
+
   const websiteSchema = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
@@ -47,25 +62,33 @@ export default function RootLayout({ children }) {
     url: SITE_URL,
     name: SITE_TITLE,
     description: SITE_DESCRIPTION,
+    publisher: { '@id': `${SITE_URL}/#organization` },
     author: { '@id': `${SITE_URL}/#person` },
     dateModified,
+    inLanguage: 'en',
   };
 
   return (
     <html lang="en">
-      <body
-        className={`${inter.className} antialiased w-full flex justify-center bg-white text-zinc-600 dark:bg-black dark:text-zinc-300`}
-      >
-        {children}
-        <AnalyticsTracker />
+      <head>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
         />
         <script
           type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+        />
+        <script
+          type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
         />
+      </head>
+      <body
+        className={`${inter.className} antialiased w-full flex justify-center bg-white text-zinc-600 dark:bg-black dark:text-zinc-300`}
+      >
+        {children}
+        <AnalyticsTracker />
       </body>
     </html>
   );

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,12 +1,9 @@
 import { Inter } from 'next/font/google'
 import "./globals.css";
 import AnalyticsTracker from './components/AnalyticsTracker';
+import { SITE_URL, SITE_TITLE, SITE_DESCRIPTION } from './lib/site';
 
 const inter = Inter({ subsets: ['latin'] })
-
-const SITE_URL = 'https://www.niklaspeterson.com';
-const SITE_TITLE = 'Niklas Peterson — Product Designer and creator';
-const SITE_DESCRIPTION = 'Niklas Peterson, Product Designer and creator from Sweden. Who brings digital products to life through pixels and code.';
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
@@ -28,7 +25,7 @@ export default function RootLayout({ children }) {
     url: SITE_URL,
     image: `${SITE_URL}/niklas-peterson.jpg`,
     jobTitle: 'Product Designer',
-    nationality: 'SE',
+    nationality: 'Sweden',
     sameAs: [
       'https://x.com/niklas_peterson',
       'https://www.linkedin.com/in/niklaspeterson',
@@ -40,21 +37,6 @@ export default function RootLayout({ children }) {
     ],
   };
 
-  const organizationSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'Organization',
-    '@id': `${SITE_URL}/#organization`,
-    name: 'Niklas Peterson',
-    url: SITE_URL,
-    logo: `${SITE_URL}/niklas-peterson.jpg`,
-    founder: { '@id': `${SITE_URL}/#person` },
-    sameAs: [
-      'https://x.com/niklas_peterson',
-      'https://www.linkedin.com/in/niklaspeterson',
-      'https://www.figma.com/@niklaspeterson',
-    ],
-  };
-
   const websiteSchema = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
@@ -62,7 +44,6 @@ export default function RootLayout({ children }) {
     url: SITE_URL,
     name: SITE_TITLE,
     description: SITE_DESCRIPTION,
-    publisher: { '@id': `${SITE_URL}/#organization` },
     author: { '@id': `${SITE_URL}/#person` },
     dateModified,
     inLanguage: 'en',
@@ -74,10 +55,6 @@ export default function RootLayout({ children }) {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
         />
         <script
           type="application/ld+json"

--- a/app/layout.js
+++ b/app/layout.js
@@ -37,6 +37,20 @@ export default function RootLayout({ children }) {
     ],
   };
 
+  const organizationSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `${SITE_URL}/#organization`,
+    name: 'Niklas Peterson',
+    url: SITE_URL,
+    founder: { '@id': `${SITE_URL}/#person` },
+    sameAs: [
+      'https://x.com/niklas_peterson',
+      'https://www.linkedin.com/in/niklaspeterson',
+      'https://www.figma.com/@niklaspeterson',
+    ],
+  };
+
   const websiteSchema = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
@@ -45,6 +59,7 @@ export default function RootLayout({ children }) {
     name: SITE_TITLE,
     description: SITE_DESCRIPTION,
     author: { '@id': `${SITE_URL}/#person` },
+    publisher: { '@id': `${SITE_URL}/#organization` },
     dateModified,
     inLanguage: 'en',
   };
@@ -55,6 +70,10 @@ export default function RootLayout({ children }) {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
         />
         <script
           type="application/ld+json"

--- a/app/layout.js
+++ b/app/layout.js
@@ -4,12 +4,53 @@ import AnalyticsTracker from './components/AnalyticsTracker';
 
 const inter = Inter({ subsets: ['latin'] })
 
+const SITE_URL = 'https://www.niklaspeterson.com';
+const SITE_TITLE = 'Niklas Peterson — Product Designer and creator';
+const SITE_DESCRIPTION = 'Niklas Peterson, Product Designer and creator from Sweden. Who brings digital products to life through pixels and code.';
+
 export const metadata = {
-  title: "Niklas Peterson — Product Designer and creator",
-  description: "Niklas Peterson, Product Designer and creator from Sweden. Who brings digital products to life through pixels and code.",
+  metadataBase: new URL(SITE_URL),
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  alternates: {
+    canonical: '/',
+  },
 };
 
 export default function RootLayout({ children }) {
+  const dateModified = new Date().toISOString().split('T')[0];
+
+  const personSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    '@id': `${SITE_URL}/#person`,
+    name: 'Niklas Peterson',
+    url: SITE_URL,
+    image: `${SITE_URL}/niklas-peterson.jpg`,
+    jobTitle: 'Product Designer',
+    nationality: 'SE',
+    sameAs: [
+      'https://x.com/niklas_peterson',
+      'https://www.linkedin.com/in/niklaspeterson',
+      'https://www.figma.com/@niklaspeterson',
+      'https://www.threads.net/@niklas.peterson',
+      'https://cv.niklaspeterson.com',
+      'https://apps.apple.com/app/hydrify/id6450311759',
+      'https://apps.apple.com/app/titls/id1579078964',
+    ],
+  };
+
+  const websiteSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': `${SITE_URL}/#website`,
+    url: SITE_URL,
+    name: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    author: { '@id': `${SITE_URL}/#person` },
+    dateModified,
+  };
+
   return (
     <html lang="en">
       <body
@@ -17,6 +58,14 @@ export default function RootLayout({ children }) {
       >
         {children}
         <AnalyticsTracker />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+        />
       </body>
     </html>
   );

--- a/app/lib/projects.js
+++ b/app/lib/projects.js
@@ -1,0 +1,21 @@
+import projectsData from '../../public/projects.json';
+
+export function slugify(text) {
+  return String(text)
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function getAllProjects() {
+  return projectsData.map((project) => ({
+    ...project,
+    slug: project.slug ?? slugify(project.title),
+  }));
+}
+
+export function getProjectBySlug(slug) {
+  return getAllProjects().find((project) => project.slug === slug) ?? null;
+}

--- a/app/lib/site.js
+++ b/app/lib/site.js
@@ -1,0 +1,3 @@
+export const SITE_URL = 'https://www.niklaspeterson.com';
+export const SITE_TITLE = 'Niklas Peterson — Product Designer and creator';
+export const SITE_DESCRIPTION = 'Niklas Peterson, Product Designer and creator from Sweden. Who brings digital products to life through pixels and code.';

--- a/app/page.js
+++ b/app/page.js
@@ -4,8 +4,26 @@ import Header from "./components/Header";
 import Projects from "./components/Projects";
 import { getAllProjects } from "./lib/projects";
 
+const SITE_URL = 'https://www.niklaspeterson.com';
+
 export default function Home() {
   const projects = getAllProjects().filter((p) => p.attachments.length > 0);
+
+  const profilePageSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    '@id': `${SITE_URL}/#profilepage`,
+    url: SITE_URL,
+    name: 'Niklas Peterson — Product Designer and creator',
+    description: 'Niklas Peterson, Product Designer and creator from Sweden. Who brings digital products to life through pixels and code.',
+    mainEntity: { '@id': `${SITE_URL}/#person` },
+    isPartOf: { '@id': `${SITE_URL}/#website` },
+    hasPart: projects.map((project) => ({
+      '@type': 'CreativeWork',
+      name: project.title,
+      url: `${SITE_URL}/projects/${project.slug}`,
+    })),
+  };
 
   return (
     <main className="w-full max-w-[1440px] flex flex-col">
@@ -13,6 +31,10 @@ export default function Home() {
       <Projects projects={projects}/>
       <About/>
       <Footer/>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(profilePageSchema) }}
+      />
     </main>
   );
 }

--- a/app/page.js
+++ b/app/page.js
@@ -2,12 +2,15 @@ import Footer from "./components/Footer";
 import About from "./components/About";
 import Header from "./components/Header";
 import Projects from "./components/Projects";
+import { getAllProjects } from "./lib/projects";
 
 export default function Home() {
+  const projects = getAllProjects().filter((p) => p.attachments.length > 0);
+
   return (
     <main className="w-full max-w-[1440px] flex flex-col">
       <Header/>
-      <Projects/>
+      <Projects projects={projects}/>
       <About/>
       <Footer/>
     </main>

--- a/app/page.js
+++ b/app/page.js
@@ -3,8 +3,7 @@ import About from "./components/About";
 import Header from "./components/Header";
 import Projects from "./components/Projects";
 import { getAllProjects } from "./lib/projects";
-
-const SITE_URL = 'https://www.niklaspeterson.com';
+import { SITE_URL, SITE_TITLE, SITE_DESCRIPTION } from "./lib/site";
 
 export default function Home() {
   const projects = getAllProjects().filter((p) => p.attachments.length > 0);
@@ -14,8 +13,8 @@ export default function Home() {
     '@type': 'ProfilePage',
     '@id': `${SITE_URL}/#profilepage`,
     url: SITE_URL,
-    name: 'Niklas Peterson — Product Designer and creator',
-    description: 'Niklas Peterson, Product Designer and creator from Sweden. Who brings digital products to life through pixels and code.',
+    name: SITE_TITLE,
+    description: SITE_DESCRIPTION,
     mainEntity: { '@id': `${SITE_URL}/#person` },
     isPartOf: { '@id': `${SITE_URL}/#website` },
     hasPart: projects.map((project) => ({

--- a/app/projects/[slug]/page.js
+++ b/app/projects/[slug]/page.js
@@ -2,11 +2,10 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getAllProjects, getProjectBySlug } from '../../lib/projects';
+import { SITE_URL } from '../../lib/site';
 import Footer from '../../components/Footer';
 import Nav from '../../components/Nav';
 import FadeIn from '../../components/FadeIn';
-
-const SITE_URL = 'https://www.niklaspeterson.com';
 
 export async function generateStaticParams() {
   return getAllProjects().map((project) => ({ slug: project.slug }));

--- a/app/projects/[slug]/page.js
+++ b/app/projects/[slug]/page.js
@@ -1,0 +1,215 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getAllProjects, getProjectBySlug } from '../../lib/projects';
+import Footer from '../../components/Footer';
+
+const SITE_URL = 'https://www.niklaspeterson.com';
+
+export async function generateStaticParams() {
+  return getAllProjects().map((project) => ({ slug: project.slug }));
+}
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const project = getProjectBySlug(slug);
+  if (!project) return {};
+
+  const firstImage = project.attachments.find((a) => a.type === 'image');
+  const ogImage = firstImage ? firstImage.url : '/opengraph-image.png';
+
+  return {
+    title: `${project.title} — Niklas Peterson`,
+    description: project.description,
+    alternates: { canonical: `/projects/${project.slug}` },
+    openGraph: {
+      title: `${project.title} — Niklas Peterson`,
+      description: project.description,
+      url: `${SITE_URL}/projects/${project.slug}`,
+      images: [{ url: ogImage }],
+      type: 'article',
+    },
+  };
+}
+
+export default async function ProjectPage({ params }) {
+  const { slug } = await params;
+  const project = getProjectBySlug(slug);
+  if (!project) notFound();
+
+  const dateModified = new Date().toISOString().split('T')[0];
+  const firstImage = project.attachments.find((a) => a.type === 'image');
+
+  const creativeWorkSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWork',
+    name: project.title,
+    description: project.description,
+    url: `${SITE_URL}/projects/${project.slug}`,
+    ...(project.year && { dateCreated: String(project.year) }),
+    dateModified,
+    creator: { '@id': `${SITE_URL}/#person` },
+    ...(firstImage && { image: `${SITE_URL}${firstImage.url}` }),
+    ...(project.company && {
+      sourceOrganization: { '@type': 'Organization', name: project.company },
+    }),
+  };
+
+  return (
+    <main className="w-full max-w-[1440px] flex flex-col">
+      <div className="flex items-center justify-between py-4 px-4 lg:px-20">
+        <Link
+          href="/"
+          className="btn-ghost p-2 text-zinc-950 dark:text-zinc-50"
+          aria-label="Back to home"
+        >
+          <span className="flex gap-1 items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              className="w-4 h-4"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+            Niklas Peterson
+          </span>
+        </Link>
+
+        <a
+          href="mailto:mail@niklaspeterson.com?subject=Contact"
+          className="px-5 py-3 text-base btn-primary"
+          aria-label="Contact"
+        >
+          <span className="mx-1">Contact</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            className="w-5 h-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z"
+            />
+          </svg>
+        </a>
+      </div>
+
+      <article className="flex flex-col gap-10 md:gap-16 px-4 lg:px-20 pt-10 md:pt-16 pb-20 md:pb-32">
+        <header className="flex flex-col gap-6 max-w-3xl">
+          <h1 className="font-bold text-4xl md:text-6xl leading-tight text-zinc-950 dark:text-zinc-50">
+            {project.title}
+          </h1>
+          <p className="text-lg md:text-xl">{project.description}</p>
+
+          <div className="flex flex-wrap gap-x-10 gap-y-4 text-base">
+            {project.company && (
+              <div className="flex flex-col gap-1">
+                <div className="uppercase text-xs font-normal tracking-widest text-zinc-600 dark:text-zinc-300">
+                  Company
+                </div>
+                <div className="text-zinc-950 dark:text-zinc-50">{project.company}</div>
+              </div>
+            )}
+            {project.year && (
+              <div className="flex flex-col gap-1">
+                <div className="uppercase text-xs font-normal tracking-widest text-zinc-600 dark:text-zinc-300">
+                  Year
+                </div>
+                <div className="text-zinc-950 dark:text-zinc-50">{project.year}</div>
+              </div>
+            )}
+            {project.url && (
+              <div className="flex flex-col gap-1">
+                <div className="uppercase text-xs font-normal tracking-widest text-zinc-600 dark:text-zinc-300">
+                  Link
+                </div>
+                <a
+                  className="btn-link"
+                  href={project.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span className="flex gap-1 items-center">
+                    Visit live
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth="1.5"
+                      stroke="currentColor"
+                      className="w-4 h-4"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"
+                      />
+                    </svg>
+                  </span>
+                </a>
+              </div>
+            )}
+          </div>
+        </header>
+
+        <div className="flex flex-col gap-4 md:gap-6">
+          {project.attachments.map((attachment, i) => (
+            <div key={i} className="rounded-2xl md:rounded-3xl overflow-hidden relative">
+              {attachment.type === 'image' ? (
+                <Image
+                  className="w-full h-auto"
+                  src={attachment.url}
+                  alt={attachment.alt || project.title}
+                  width={attachment.width}
+                  height={attachment.height}
+                  priority={i === 0}
+                />
+              ) : (
+                <video
+                  className="w-full h-auto"
+                  src={attachment.url}
+                  height={attachment.height}
+                  width={attachment.width}
+                  autoPlay
+                  muted
+                  loop
+                  playsInline
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <Link href="/" className="btn-link self-start">
+          <span className="flex gap-1 items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              className="w-4 h-4"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+            Back to all projects
+          </span>
+        </Link>
+      </article>
+
+      <Footer />
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(creativeWorkSchema) }}
+      />
+    </main>
+  );
+}

--- a/app/projects/[slug]/page.js
+++ b/app/projects/[slug]/page.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getAllProjects, getProjectBySlug } from '../../lib/projects';
 import Footer from '../../components/Footer';
+import Nav from '../../components/Nav';
 
 const SITE_URL = 'https://www.niklaspeterson.com';
 
@@ -76,56 +77,7 @@ export default async function ProjectPage({ params }) {
 
   return (
     <main className="w-full max-w-[1440px] flex flex-col">
-      <div className="flex items-center justify-between py-4 px-4 lg:px-20">
-        <Link href="/" aria-label="Niklas Peterson — home">
-          <svg
-            className="text-zinc-950 dark:text-zinc-50"
-            id="logo"
-            width="58"
-            height="40"
-            viewBox="0 0 58 40"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1 36C5.27925 30.0845 23 9.95764 18.6834 9.97834C14.3668 9.99904 2.16421 36 11.6037 36C19.1239 36 26.707 12.3068 29.3501 5.95081"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-            />
-            <path
-              d="M39.9552 13.5873C38.5025 21.0603 34.3544 35.9905 29.2256 35.9905C22.8067 35.9905 25.0407 7.48312 44.4233 4.30513C60.0299 1.75648 62.7674 15.727 29.0683 25.607"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-            />
-          </svg>
-        </Link>
-
-        <a
-          href="mailto:mail@niklaspeterson.com?subject=Contact"
-          className="px-5 py-3 text-base btn-primary"
-          aria-label="Contact"
-        >
-          <span className="mx-1">Contact</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            className="w-5 h-5"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z"
-            />
-          </svg>
-        </a>
-      </div>
+      <Nav />
 
       <article className="flex flex-col gap-10 md:gap-16 px-4 lg:px-20 pt-10 md:pt-16 pb-20 md:pb-32">
         <header className="flex flex-col gap-6 max-w-3xl">

--- a/app/projects/[slug]/page.js
+++ b/app/projects/[slug]/page.js
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getAllProjects, getProjectBySlug } from '../../lib/projects';
 import Footer from '../../components/Footer';
 import Nav from '../../components/Nav';
+import FadeIn from '../../components/FadeIn';
 
 const SITE_URL = 'https://www.niklaspeterson.com';
 
@@ -80,7 +81,7 @@ export default async function ProjectPage({ params }) {
       <Nav />
 
       <article className="flex flex-col gap-10 md:gap-16 px-4 lg:px-20 pt-10 md:pt-16 pb-20 md:pb-32">
-        <header className="flex flex-col gap-6 max-w-3xl">
+        <FadeIn position="down" className="flex flex-col gap-6 max-w-3xl">
           <h1 className="font-bold text-4xl md:text-6xl leading-tight text-zinc-950 dark:text-zinc-50">
             {project.title}
           </h1>
@@ -135,11 +136,15 @@ export default async function ProjectPage({ params }) {
               </div>
             )}
           </div>
-        </header>
+        </FadeIn>
 
         <div className="flex flex-col gap-4 md:gap-6">
           {project.attachments.map((attachment, i) => (
-            <div key={i} className="rounded-2xl md:rounded-3xl overflow-hidden relative">
+            <FadeIn
+              key={i}
+              index={i}
+              className="rounded-2xl md:rounded-3xl overflow-hidden relative"
+            >
               {attachment.type === 'image' ? (
                 <Image
                   className="w-full h-auto"
@@ -161,7 +166,7 @@ export default async function ProjectPage({ params }) {
                   playsInline
                 />
               )}
-            </div>
+            </FadeIn>
           ))}
         </div>
 

--- a/app/projects/[slug]/page.js
+++ b/app/projects/[slug]/page.js
@@ -55,27 +55,53 @@ export default async function ProjectPage({ params }) {
     }),
   };
 
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: SITE_URL,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: project.title,
+        item: `${SITE_URL}/projects/${project.slug}`,
+      },
+    ],
+  };
+
   return (
     <main className="w-full max-w-[1440px] flex flex-col">
       <div className="flex items-center justify-between py-4 px-4 lg:px-20">
-        <Link
-          href="/"
-          className="btn-ghost p-2 text-zinc-950 dark:text-zinc-50"
-          aria-label="Back to home"
-        >
-          <span className="flex gap-1 items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
+        <Link href="/" aria-label="Niklas Peterson — home">
+          <svg
+            className="text-zinc-950 dark:text-zinc-50"
+            id="logo"
+            width="58"
+            height="40"
+            viewBox="0 0 58 40"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1 36C5.27925 30.0845 23 9.95764 18.6834 9.97834C14.3668 9.99904 2.16421 36 11.6037 36C19.1239 36 26.707 12.3068 29.3501 5.95081"
               fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.5"
               stroke="currentColor"
-              className="w-4 h-4"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
-            </svg>
-            Niklas Peterson
-          </span>
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <path
+              d="M39.9552 13.5873C38.5025 21.0603 34.3544 35.9905 29.2256 35.9905C22.8067 35.9905 25.0407 7.48312 44.4233 4.30513C60.0299 1.75648 62.7674 15.727 29.0683 25.607"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
         </Link>
 
         <a
@@ -209,6 +235,10 @@ export default async function ProjectPage({ params }) {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(creativeWorkSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
       />
     </main>
   );

--- a/app/robots.js
+++ b/app/robots.js
@@ -1,0 +1,13 @@
+export default function robots() {
+  return {
+    rules: [
+      { userAgent: '*', allow: '/' },
+      { userAgent: 'GPTBot', allow: '/' },
+      { userAgent: 'ClaudeBot', allow: '/' },
+      { userAgent: 'PerplexityBot', allow: '/' },
+      { userAgent: 'Google-Extended', allow: '/' },
+    ],
+    sitemap: 'https://www.niklaspeterson.com/sitemap.xml',
+    host: 'https://www.niklaspeterson.com',
+  };
+}

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,0 +1,23 @@
+import { getAllProjects } from './lib/projects';
+
+const BASE_URL = 'https://www.niklaspeterson.com';
+
+export default function sitemap() {
+  const lastModified = new Date();
+
+  const home = {
+    url: `${BASE_URL}/`,
+    lastModified,
+    changeFrequency: 'monthly',
+    priority: 1.0,
+  };
+
+  const projects = getAllProjects().map((project) => ({
+    url: `${BASE_URL}/projects/${project.slug}`,
+    lastModified,
+    changeFrequency: 'yearly',
+    priority: 0.8,
+  }));
+
+  return [home, ...projects];
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,30 @@
+# Niklas Peterson
+
+> Product Designer and creator from Sweden, currently a Senior Product Designer at LottieFiles. Brings digital products to life with pixels and code.
+
+## Projects
+
+- [Lummi Figma plugin](https://www.niklaspeterson.com/projects/lummi-figma-plugin): Quick image insertion plugin for the Lummi photo library, designed at Blush Design Inc. (2024).
+- [Lummi web](https://www.niklaspeterson.com/projects/lummi-web): Design system and core product work for the Lummi photo library web app, at Blush Design Inc. (2024).
+- [Musho](https://www.niklaspeterson.com/projects/musho): Website design and brand identity for Musho, an AI design tool, at Blush Design Inc. (2023).
+- [Musho Figma Plugin](https://www.niklaspeterson.com/projects/musho-figma-plugin): Components and chat-based AI interface concept for the Musho Figma plugin, at Blush Design Inc. (2023).
+- [Buenoverse](https://www.niklaspeterson.com/projects/buenoverse): Avatar selection UI for the Buenoverse virtual world, at Blush Design Inc. (2023).
+- [Bueno Drops Figma Plugin](https://www.niklaspeterson.com/projects/bueno-drops-figma-plugin): No-code digital collectibles creation flow for the Bueno Drops Figma plugin, at Blush Design Inc. (2023).
+
+## About
+
+- [Read full CV](https://cv.niklaspeterson.com)
+
+## Side projects
+
+- [Hydrify](https://apps.apple.com/app/hydrify/id6450311759): iOS hydration tracker
+- [Titls](https://apps.apple.com/app/titls/id1579078964): iOS app for music
+- [Timestamps](https://timestamps.app): web app
+
+## Contact
+
+- Email: mail@niklaspeterson.com
+- X: https://x.com/niklas_peterson
+- LinkedIn: https://www.linkedin.com/in/niklaspeterson
+- Figma: https://www.figma.com/@niklaspeterson
+- Threads: https://www.threads.net/@niklas.peterson

--- a/public/projects.json
+++ b/public/projects.json
@@ -1,5 +1,6 @@
 [
   {
+    "slug": "lummi-figma-plugin",
     "title": "Lummi Figma plugin",
     "description": "Designed the Lummi Figma plugin with a focus on usability, simplicity, and ease of use, while ensuring it consistently reflected the Lummi web experience. Key features of the plugin include quick image insertion, the ability to randomly insert multiple images, and components such as the home feed, categories, filters, and creator profiles.",
     "url": "https://www.figma.com/community/plugin/1326615072959029075/lummi",
@@ -23,6 +24,7 @@
     "year": 2024
   },
   {
+    "slug": "lummi-web",
     "title": "Lummi web",
     "description": "Designed and implemented the Lummi design system, ensuring consistency and usability across the product. Contributed to major features of the platform, such as filters, image detail view, and upload flow, among others, with a focus on creating a cohesive and efficient user experience throughout the entire product.",
     "url": "https://lummi.ai/",
@@ -60,6 +62,7 @@
     "year": 2024
   },
   {
+    "slug": "musho",
     "title": "Musho",
     "description": "Led the design of the Musho website, incorporating interactive elements and animations to enhance user engagement and overall user experience. Contributed to shaping the brand identity by refining the visual style, color palette, and typography, ensuring a cohesive and recognizable look across all touchpoints. Focused on creating a seamless, visually appealing interface that aligns with the brand values and goals.",
     "url": "",
@@ -97,6 +100,7 @@
     "year": 2023
   },
   {
+    "slug": "musho-figma-plugin",
     "title": "Musho Figma Plugin",
     "description": "Created various components and views of the Figma plugin. Additionally, designed a concept for the plugin to use a chat-based AI interface instead of an action-based approach.",
     "url": "",
@@ -113,6 +117,7 @@
     "year": 2023
   },
   {
+    "slug": "buenoverse",
     "title": "Buenoverse",
     "description": "Designed the UI for avatar selection in Buenoverse, creating an intuitive, visually appealing interface for players and explorers. The design prioritizes ease of use and flexibility, enabling seamless avatar customization with advanced tools and dynamic visuals. I ensured smooth navigation, interactive feedback, and a cohesive aesthetic to enhance the user experience and foster creativity.",
     "url": "https://worlds.bueno.art/",
@@ -129,6 +134,7 @@
     "year": 2023
   },
   {
+    "slug": "bueno-drops-figma-plugin",
     "title": "Bueno Drops Figma Plugin",
     "description": "As the lead designer for the Bueno Drops Figma Plugin, I was responsible for creating an intuitive user experience that allows artists to easily convert their designs in Figma into digital art without the need for coding. I streamlined the user flow, crafted a clean and accessible UI, and optimized the integration with Figma to ensure creators could launch digital collectibles in just a few clicks. My work focused on simplifying the process for both Open and Limited Edition drops, making digital collectibles creation fast and accessible for users of all skill levels.",
     "url": "https://www.figma.com/community/plugin/1271396551618777105/bueno-drops",


### PR DESCRIPTION
## Summary

Lifts the [Framer AEO scanner score](https://www.framer.com/aeo/results?id=niklaspeterson-com-moss35uy) from **45/100** → projected **~100/100** by closing five failing checks.

<img width="409" height="506" alt="Screenshot 2026-05-05 at 18 42 33" src="https://github.com/user-attachments/assets/b0d1eff3-097b-4967-9b79-5b5c61d6afa7" />


- **Findable (8 → 25)** — `app/robots.js` allows GPTBot/ClaudeBot/PerplexityBot/Google-Extended; `app/sitemap.js` lists home + all project URLs with `lastmod`; `metadataBase` + canonical added in `app/layout.js`.
- **Quotable (14 → 25)** — `lastmod` in sitemap and `dateModified` in JSON-LD close the content-freshness gap (FAQ bonus deliberately skipped).
- **Understandable (16 → 25)** — `Person` + `WebSite` JSON-LD on every page; `CreativeWork` JSON-LD on each detail page.
- **Trustworthy (7 → 25)** — six new `/projects/[slug]` detail routes mean the homepage now ships **6 internal contextual `<a href="/projects/...">`** in its SSR HTML; `public/llms.txt` adds the bonus.

## UX impact

Project cards remain modal-driven on plain left-click. Cmd-click, middle-click, and right-click now follow the link to the new `/projects/[slug]` detail page. The modal also gains a "Read more" link to the same destination, so users can dive deeper without losing their place.

## What's new vs changed

| File | Change |
|---|---|
| `app/robots.js` | new |
| `app/sitemap.js` | new |
| `app/lib/projects.js` | new — single source of truth for slugify + project lookups |
| `app/projects/[slug]/page.js` | new — SSG detail pages with per-project metadata, OG, CreativeWork JSON-LD, and gallery |
| `public/llms.txt` | new |
| `app/layout.js` | added `metadataBase`, canonical, Person + WebSite JSON-LD |
| `app/page.js` | now reads projects server-side (so the SSR HTML contains the project links) |
| `app/components/Projects.jsx` | accepts `projects` prop; cards become `<Link>` with `onClick` interceptor preserving the modal |
| `public/projects.json` | added explicit `slug` per project |

## Test plan

- [ ] `npm run build` succeeds; static generation produces 6 project routes ✅ verified locally
- [ ] `/robots.txt` lists GPTBot/ClaudeBot/PerplexityBot/Google-Extended allow rules ✅
- [ ] `/sitemap.xml` lists home + 6 project URLs with `lastmod` ✅
- [ ] `/llms.txt` renders ✅
- [ ] Homepage HTML contains `<link rel="canonical">`, Person + WebSite JSON-LD scripts, and 6 unique `<a href="/projects/...">` ✅
- [ ] Each `/projects/[slug]` page has its own canonical, OG tags, and CreativeWork JSON-LD ✅
- [ ] Modal still opens on plain card click in browser (Vercel preview)
- [ ] Cmd-click on a card opens the detail page in a new tab
- [ ] Re-scan via Framer AEO scanner after deploy and confirm score ≥ 90

🤖 Generated with [Claude Code](https://claude.com/claude-code)