### PR TITLE
refactor: extract logo SVG into a Logo component

### DIFF
--- a/app/components/Logo.jsx
+++ b/app/components/Logo.jsx
@@ -1,0 +1,28 @@
+export default function Logo() {
+  return (
+    <svg
+      className="text-zinc-950 dark:text-zinc-50"
+      id="logo"
+      width="58"
+      height="40"
+      viewBox="0 0 58 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 36C5.27925 30.0845 23 9.95764 18.6834 9.97834C14.3668 9.99904 2.16421 36 11.6037 36C19.1239 36 26.707 12.3068 29.3501 5.95081"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M39.9552 13.5873C38.5025 21.0603 34.3544 35.9905 29.2256 35.9905C22.8067 35.9905 25.0407 7.48312 44.4233 4.30513C60.0299 1.75648 62.7674 15.727 29.0683 25.607"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import FadeIn from './FadeIn';
+import Logo from './Logo';
 
 export default function Nav({ className = '' }) {
   return (
@@ -8,30 +9,7 @@ export default function Nav({ className = '' }) {
       className={`w-full max-w-[1440px] flex items-center justify-between py-4 px-4 lg:px-20 ${className}`}
     >
       <Link href="/" aria-label="Niklas Peterson — home">
-        <svg
-          className="text-zinc-950 dark:text-zinc-50"
-          id="logo"
-          width="58"
-          height="40"
-          viewBox="0 0 58 40"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1 36C5.27925 30.0845 23 9.95764 18.6834 9.97834C14.3668 9.99904 2.16421 36 11.6037 36C19.1239 36 26.707 12.3068 29.3501 5.95081"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          />
-          <path
-            d="M39.9552 13.5873C38.5025 21.0603 34.3544 35.9905 29.2256 35.9905C22.8067 35.9905 25.0407 7.48312 44.4233 4.30513C60.0299 1.75648 62.7674 15.727 29.0683 25.607"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-          />
-        </svg>
+        <Logo />
       </Link>
 
       <a


### PR DESCRIPTION
Move the inline home-link SVG out of Nav into a dedicated Logo component. The CSS draw-on-load animation (svg#logo) is unchanged.