### PR TITLE
Add prev/next project navigation

### DIFF
--- a/app/components/ProjectNav.jsx
+++ b/app/components/ProjectNav.jsx
@@ -1,0 +1,81 @@
+import Image from "next/image";
+import Link from "next/link";
+
+// Prev/next pager for the project detail page. Mirrors the modal's ModalNav
+// design, but navigates between pages. prefetch={false} keeps Safari/Next from
+// eagerly loading the (media-heavy) neighbor route on hover.
+export default function ProjectNav({ prev, next }) {
+  if (!prev || !next || prev.slug === next.slug) return null;
+  return (
+    <nav className="flex items-center justify-between gap-4">
+      <NavLink project={prev} dir="prev" />
+      <NavLink project={next} dir="next" />
+    </nav>
+  );
+}
+
+function NavLink({ project, dir }) {
+  const isPrev = dir === "prev";
+  return (
+    <Link
+      href={`/projects/${project.slug}`}
+      prefetch={false}
+      aria-label={`${isPrev ? "Previous" : "Next"} project: ${project.title}`}
+      className={`group flex items-center gap-3 rounded-xl p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900 ${
+        isPrev ? "" : "flex-row-reverse"
+      }`}
+    >
+      <Thumb media={project.attachments[0]} title={project.title} />
+      <span
+        className={`flex min-w-0 flex-col gap-0.5 ${isPrev ? "items-start" : "items-end"}`}
+      >
+        <span className="flex items-center gap-1 text-[11px] font-normal tracking-widest text-zinc-400 uppercase dark:text-zinc-500">
+          {isPrev && <Chevron dir="left" />}
+          {isPrev ? "Previous" : "Next"}
+          {!isPrev && <Chevron dir="right" />}
+        </span>
+        <span className="max-w-[34vw] truncate text-sm font-medium text-zinc-950 md:max-w-[15rem] dark:text-zinc-50">
+          {project.title}
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function Thumb({ media, title }) {
+  return (
+    <span className="relative aspect-[16/10] w-14 shrink-0 overflow-hidden rounded-md bg-zinc-100 md:w-16 dark:bg-zinc-900">
+      {media.type === "image" ? (
+        <Image src={media.url} alt={title} fill sizes="64px" className="object-cover" />
+      ) : (
+        // #t=0.1 nudges the browser to render the first frame as a still poster
+        <video
+          src={`${media.url}#t=0.1`}
+          className="h-full w-full object-cover"
+          muted
+          playsInline
+          preload="metadata"
+        />
+      )}
+    </span>
+  );
+}
+
+function Chevron({ dir }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="h-3.5 w-3.5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d={dir === "left" ? "M15.75 19.5 8.25 12l7.5-7.5" : "m8.25 4.5 7.5 7.5-7.5 7.5"}
+      />
+    </svg>
+  );
+}

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import FadeIn from "./FadeIn";
 
 export default function Projects({ projects = [] }) {
@@ -15,6 +14,29 @@ export default function Projects({ projects = [] }) {
   const closeProject = () => {
     setSelectedProject(null);
   };
+
+  const overlayRef = useRef(null);
+
+  const navigateTo = (project) => {
+    setSelectedProject(project);
+    if (overlayRef.current) overlayRef.current.scrollTop = 0;
+  };
+
+  const currentIndex = selectedProject
+    ? projects.findIndex(
+        (p) =>
+          (p.slug ?? p.title) === (selectedProject.slug ?? selectedProject.title),
+      )
+    : -1;
+  // Wrap around at the ends so both controls always have a target.
+  const prevProject =
+    currentIndex >= 0
+      ? projects[(currentIndex - 1 + projects.length) % projects.length]
+      : null;
+  const nextProject =
+    currentIndex >= 0
+      ? projects[(currentIndex + 1) % projects.length]
+      : null;
 
   return (
     <>
@@ -36,12 +58,13 @@ export default function Projects({ projects = [] }) {
 
       {selectedProject && (
         <div
+          ref={overlayRef}
           className="fixed top-0 right-0 bottom-0 left-0 z-10 h-screen w-screen overflow-auto bg-white/25 backdrop-blur-lg md:p-10 dark:bg-black/25"
           onClick={closeProject}
         >
           <div
             onClick={(e) => e.stopPropagation()}
-            className="mx-auto flex max-w-360 animate-fadeUp flex-col gap-10 border-zinc-200 bg-white pt-6 pb-1 md:h-fit md:rounded-3xl md:border md:pt-10 md:pb-2 dark:bg-black dark:md:border-zinc-800"
+            className="mx-auto flex max-w-360 md:animate-fadeUp flex-col gap-10 border-zinc-200 bg-white pt-6 pb-1 md:h-fit md:rounded-3xl md:border md:pt-10 md:pb-2 dark:bg-black dark:md:border-zinc-800"
           >
             <div className="flex flex-col gap-6 px-4 md:gap-8 md:px-10">
               <div className="flex items-center justify-between">
@@ -102,6 +125,14 @@ export default function Projects({ projects = [] }) {
             </div>
 
             <ModalGallery attachments={selectedProject.attachments} />
+
+            {prevProject && nextProject && prevProject !== nextProject && (
+              <ModalNav
+                prev={prevProject}
+                next={nextProject}
+                onNavigate={navigateTo}
+              />
+            )}
           </div>
         </div>
       )}
@@ -110,19 +141,19 @@ export default function Projects({ projects = [] }) {
 }
 
 function ModalGallery({ attachments }) {
-  const isSingle = attachments.length === 1;
-  const itemClass = isSingle ? "relative md:w-full" : "relative md:snap-center";
-  const mediaClass = isSingle
-    ? "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
-    : "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
+  // const isSingle = attachments.length === 1;
+  // const itemClass = isSingle ? "relative md:w-full" : "relative md:snap-center";
+  // const mediaClass = isSingle
+  //     ? "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
+  //     : "rounded-lg w-auto max-h-[60vh] max-h-[600px] max-w-[calc(100vw-32px)] md:max-w-[80vw]";
 
   return (
-    <div className="flex animate-fadeUp flex-col items-center gap-4 px-4 pb-5 md:snap-x md:snap-mandatory md:flex-row md:gap-6 md:overflow-x-auto md:px-10 md:pb-8">
+    <div className="flex animate-fadeUp flex-col items-center gap-4 px-4 pb-5 md:gap-6 md:overflow-x-auto md:px-10 md:pb-8">
       {attachments.map((attachment, i) => (
-        <div key={i} className={itemClass}>
+        <div key={i} className="relative md:w-full">
           {attachment.type === "image" ? (
             <Image
-              className={mediaClass}
+              className="rounded-lg w-auto max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
               src={attachment.url}
               alt={attachment.alt}
               height={attachment.height}
@@ -130,7 +161,7 @@ function ModalGallery({ attachments }) {
             />
           ) : (
             <video
-              className={mediaClass}
+              className="rounded-lg w-auto max-w-[calc(100vw-32px)] md:w-full md:h-auto md:max-w-full md:max-h-none"
               src={attachment.url}
               height={attachment.height}
               width={attachment.width}
@@ -146,18 +177,91 @@ function ModalGallery({ attachments }) {
   );
 }
 
-function ProjectContent({ project, onOpen, priority }) {
-  const handleClick = (e) => {
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
-    e.preventDefault();
-    onOpen(project);
-  };
-
+function ModalNav({ prev, next, onNavigate }) {
   return (
-    <Link
-      href={`/projects/${project.slug}`}
+    <div className="flex items-center justify-between gap-4 px-2 pb-2 md:px-8">
+      <NavButton project={prev} dir="prev" onNavigate={onNavigate} />
+      <NavButton project={next} dir="next" onNavigate={onNavigate} />
+    </div>
+  );
+}
+
+function NavButton({ project, dir, onNavigate }) {
+  const isPrev = dir === "prev";
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(project)}
+      aria-label={`${isPrev ? "Previous" : "Next"} project: ${project.title}`}
+      className={`group flex items-center gap-3 rounded-xl p-2 ${isPrev ? "pr-4" : "pl-4"} transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900 ${
+        isPrev ? "" : "flex-row-reverse"
+      }`}
+    >
+      <NavThumb media={project.attachments[0]} title={project.title} />
+      <span
+        className={`flex min-w-0 flex-col gap-0.5 ${isPrev ? "items-start" : "items-end"}`}
+      >
+        <span className="flex items-center gap-1 text-[11px] font-normal tracking-widest text-zinc-400 uppercase dark:text-zinc-500">
+          {isPrev && <Chevron dir="left" />}
+          {isPrev ? "Previous" : "Next"}
+          {!isPrev && <Chevron dir="right" />}
+        </span>
+        <span className="max-w-[34vw] truncate text-sm font-medium text-zinc-950 md:max-w-[15rem] dark:text-zinc-50">
+          {project.title}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function NavThumb({ media, title }) {
+  return (
+    <span className="relative aspect-[16/10] w-14 shrink-0 overflow-hidden rounded-md bg-zinc-100 md:w-16 dark:bg-zinc-900">
+      {media.type === "image" ? (
+        <Image src={media.url} alt={title} fill sizes="64px" className="object-cover" />
+      ) : (
+        // #t=0.1 nudges the browser to render the first frame as a still poster
+        <video
+          src={`${media.url}#t=0.1`}
+          className="h-full w-full object-cover"
+          muted
+          playsInline
+          preload="metadata"
+        />
+      )}
+    </span>
+  );
+}
+
+function Chevron({ dir }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="h-3.5 w-3.5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d={dir === "left" ? "M15.75 19.5 8.25 12l7.5-7.5" : "m8.25 4.5 7.5 7.5-7.5 7.5"}
+      />
+    </svg>
+  );
+}
+
+function ProjectContent({ project, onOpen, priority }) {
+  // Plain <button>, NOT a link: a navigable <a href="/projects/[slug]"> (or
+  // next/link) makes Safari speculatively load that heavy detail route on
+  // hover/mousedown, freezing the main thread ~1-2s before the modal renders.
+  // The project routes stay discoverable via sitemap.xml + JSON-LD instead.
+  return (
+    <button
+      type="button"
       className="group flex h-full w-full cursor-pointer flex-col gap-5 text-left"
-      onClick={handleClick}
+      onClick={() => onOpen(project)}
       aria-label={`Open ${project.title} project`}
     >
       {project.attachments.map((media, index) => {
@@ -195,6 +299,6 @@ function ProjectContent({ project, onOpen, priority }) {
           {project.description}
         </div>
       </div>
-    </Link>
+    </button>
   );
 }

--- a/app/lib/projects.js
+++ b/app/lib/projects.js
@@ -19,3 +19,14 @@ export function getAllProjects() {
 export function getProjectBySlug(slug) {
   return getAllProjects().find((project) => project.slug === slug) ?? null;
 }
+
+// Neighbors for prev/next navigation. Wraps around at the ends.
+export function getAdjacentProjects(slug) {
+  const all = getAllProjects();
+  const i = all.findIndex((project) => project.slug === slug);
+  if (i === -1) return { prev: null, next: null };
+  return {
+    prev: all[(i - 1 + all.length) % all.length],
+    next: all[(i + 1) % all.length],
+  };
+}

--- a/app/projects/[slug]/page.js
+++ b/app/projects/[slug]/page.js
@@ -1,11 +1,16 @@
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getAllProjects, getProjectBySlug } from "../../lib/projects";
+import {
+  getAllProjects,
+  getProjectBySlug,
+  getAdjacentProjects,
+} from "../../lib/projects";
 import { SITE_URL } from "../../lib/site";
 import Footer from "../../components/Footer";
 import Nav from "../../components/Nav";
 import FadeIn from "../../components/FadeIn";
+import ProjectNav from "../../components/ProjectNav";
 
 export async function generateStaticParams() {
   return getAllProjects().map((project) => ({ slug: project.slug }));
@@ -40,6 +45,7 @@ export default async function ProjectPage({ params }) {
 
   const dateModified = new Date().toISOString().split("T")[0];
   const firstImage = project.attachments.find((a) => a.type === "image");
+  const { prev, next } = getAdjacentProjects(slug);
 
   const creativeWorkSchema = {
     "@context": "https://schema.org",
@@ -173,25 +179,7 @@ export default async function ProjectPage({ params }) {
           ))}
         </div>
 
-        <Link href="/" className="btn-link self-start">
-          <span className="flex items-center gap-1">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.5"
-              stroke="currentColor"
-              className="h-4 w-4"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15.75 19.5 8.25 12l7.5-7.5"
-              />
-            </svg>
-            Back to all projects
-          </span>
-        </Link>
+        <ProjectNav prev={prev} next={next} />
       </article>
 
       <Footer />

--- a/public/projects.json
+++ b/public/projects.json
@@ -63,7 +63,7 @@
   },
   {
     "slug": "musho",
-    "title": "Musho",
+    "title": "Musho web",
     "description": "Led the design of the Musho website, incorporating interactive elements and animations to enhance user engagement and overall user experience. Contributed to shaping the brand identity by refining the visual style, color palette, and typography, ensuring a cohesive and recognizable look across all touchpoints. Focused on creating a seamless, visually appealing interface that aligns with the brand values and goals.",
     "url": "",
     "attachments": [


### PR DESCRIPTION
## What

Adds a **previous/next pager** (thumbnail + project name, wrap-around at the ends) so visitors can move between projects without returning to the index:

- **Project modal** (`Projects.jsx`) — navigates in place and resets scroll to top.
- **Detail page** (`/projects/[slug]`) — a matching pager at the bottom.

## Notes

- The detail-page pager uses `<Link prefetch={false}>` on purpose. A navigable link to a `/projects/[slug]` route makes Safari speculatively load that media-heavy page on hover/mousedown, which stalled the main thread ~1–2s. Disabling eager prefetch keeps navigation smooth. (For the same reason, the homepage project cards are plain `<button>`s that open the modal — routes stay discoverable via `sitemap.xml` + JSON-LD.)
- New `getAdjacentProjects(slug)` helper in `lib/projects.js`.
- Minor content tweak bundled in: retitled the Musho project to "Musho web".

## Test

- Open any project on the homepage → modal opens instantly; prev/next swaps projects.
- Visit `/projects/[slug]` → pager at the bottom navigates between project pages.
- Verify in Safari that clicking prev/next on a detail page has no multi-second freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)