### PR TITLE
fix: prevent mobile horizontal scroll from prev/next nav

### DIFF
--- a/app/components/ProjectNav.jsx
+++ b/app/components/ProjectNav.jsx
@@ -21,7 +21,7 @@ function NavLink({ project, dir }) {
       href={`/projects/${project.slug}`}
       prefetch={false}
       aria-label={`${isPrev ? "Previous" : "Next"} project: ${project.title}`}
-      className={`group flex items-center gap-3 rounded-xl p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900 ${
+      className={`group flex max-w-[calc(50%-0.5rem)] min-w-0 items-center gap-3 rounded-xl p-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900 ${
         isPrev ? "" : "flex-row-reverse"
       }`}
     >
@@ -34,7 +34,7 @@ function NavLink({ project, dir }) {
           {isPrev ? "Previous" : "Next"}
           {!isPrev && <Chevron dir="right" />}
         </span>
-        <span className="max-w-[34vw] truncate text-sm font-medium text-zinc-950 md:max-w-[15rem] dark:text-zinc-50">
+        <span className="max-w-full truncate text-sm font-medium text-zinc-950 md:max-w-[15rem] dark:text-zinc-50">
           {project.title}
         </span>
       </span>

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -193,7 +193,7 @@ function NavButton({ project, dir, onNavigate }) {
       type="button"
       onClick={() => onNavigate(project)}
       aria-label={`${isPrev ? "Previous" : "Next"} project: ${project.title}`}
-      className={`group flex items-center gap-3 rounded-xl p-2 ${isPrev ? "pr-4" : "pl-4"} transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900 ${
+      className={`group flex max-w-[calc(50%-0.5rem)] min-w-0 items-center gap-3 rounded-xl p-2 ${isPrev ? "pr-4" : "pl-4"} transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-900 ${
         isPrev ? "" : "flex-row-reverse"
       }`}
     >
@@ -206,7 +206,7 @@ function NavButton({ project, dir, onNavigate }) {
           {isPrev ? "Previous" : "Next"}
           {!isPrev && <Chevron dir="right" />}
         </span>
-        <span className="max-w-[34vw] truncate text-sm font-medium text-zinc-950 md:max-w-[15rem] dark:text-zinc-50">
+        <span className="max-w-full truncate text-sm font-medium text-zinc-950 md:max-w-[15rem] dark:text-zinc-50">
           {project.title}
         </span>
       </span>


### PR DESCRIPTION
Each nav button sized to its content (thumb + up-to-34vw title + padding), so two side by side could exceed the viewport width and push the page wider. Cap each button at half the row (max-w-[calc(50%-0.5rem)] min-w-0) and let the title truncate (max-w-full) instead of growing. Applies to both the modal pager (ModalNav) and the detail-page pager (ProjectNav). Desktop layout unchanged.