### PR TITLE
chore: restore formatting checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    ignore:
+      # eslint-config-next still bundles plugins whose peer ranges stop at ESLint 9.
+      - dependency-name: "eslint"
+        versions: [">=10"]
     groups:
       react-stack:
         patterns:

--- a/app/api/analytics/pageview/route.js
+++ b/app/api/analytics/pageview/route.js
@@ -65,7 +65,8 @@ function normalizeReferrer(value) {
 
   try {
     const referrer = new URL(value.trim());
-    if (referrer.protocol !== "http:" && referrer.protocol !== "https:") return null;
+    if (referrer.protocol !== "http:" && referrer.protocol !== "https:")
+      return null;
 
     referrer.search = "";
     referrer.hash = "";
@@ -77,16 +78,30 @@ function normalizeReferrer(value) {
 
 export async function POST(request) {
   if (!isSameOriginRequest(request)) {
-    return NextResponse.json({ error: "Invalid request origin" }, { status: 403 });
+    return NextResponse.json(
+      { error: "Invalid request origin" },
+      { status: 403 },
+    );
   }
 
-  if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
-    return NextResponse.json({ error: "Content-Type must be application/json" }, { status: 415 });
+  if (
+    !request.headers
+      .get("content-type")
+      ?.toLowerCase()
+      .startsWith("application/json")
+  ) {
+    return NextResponse.json(
+      { error: "Content-Type must be application/json" },
+      { status: 415 },
+    );
   }
 
   const contentLength = Number(request.headers.get("content-length"));
   if (Number.isFinite(contentLength) && contentLength > MAX_BODY_LENGTH) {
-    return NextResponse.json({ error: "Request body is too large" }, { status: 413 });
+    return NextResponse.json(
+      { error: "Request body is too large" },
+      { status: 413 },
+    );
   }
 
   const rateLimit = checkRateLimit(request, PAGEVIEW_RATE_LIMIT);
@@ -109,7 +124,10 @@ export async function POST(request) {
   try {
     const body = await request.text();
     if (body.length > MAX_BODY_LENGTH) {
-      return NextResponse.json({ error: "Request body is too large" }, { status: 413 });
+      return NextResponse.json(
+        { error: "Request body is too large" },
+        { status: 413 },
+      );
     }
     payload = JSON.parse(body);
   } catch {
@@ -117,22 +135,34 @@ export async function POST(request) {
   }
 
   if (!isRecord(payload)) {
-    return NextResponse.json({ error: "Invalid pageview payload" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid pageview payload" },
+      { status: 400 },
+    );
   }
 
   const { page, visitorId, sessionId, referrer } = payload;
-  if (!isValidPage(page) || !isValidUuid(visitorId) || !isValidUuid(sessionId)) {
-    return NextResponse.json({ error: "Invalid pageview payload" }, { status: 400 });
+  if (
+    !isValidPage(page) ||
+    !isValidUuid(visitorId) ||
+    !isValidUuid(sessionId)
+  ) {
+    return NextResponse.json(
+      { error: "Invalid pageview payload" },
+      { status: 400 },
+    );
   }
 
   let error;
   try {
-    ({ error } = await getSupabase().from("pageviews_np").insert({
-      page,
-      visitor_id: visitorId,
-      session_id: sessionId,
-      referrer: normalizeReferrer(referrer),
-    }));
+    ({ error } = await getSupabase()
+      .from("pageviews_np")
+      .insert({
+        page,
+        visitor_id: visitorId,
+        session_id: sessionId,
+        referrer: normalizeReferrer(referrer),
+      }));
   } catch {
     return NextResponse.json(
       { error: "Failed to track pageview" },

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -129,8 +129,11 @@ export default function Footer() {
         </div>
       </div>
 
-        <div aria-hidden="true" className="absolute right-0 bottom-0 left-0 -z-10 flex h-full max-w-full rotate-180 justify-center overflow-hidden blur-[120px]">
-          <LottieAnimation />
+      <div
+        aria-hidden="true"
+        className="absolute right-0 bottom-0 left-0 -z-10 flex h-full max-w-full rotate-180 justify-center overflow-hidden blur-[120px]"
+      >
+        <LottieAnimation />
       </div>
     </FadeIn>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,11 +1,11 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @theme {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
 
   --animate-fadeUp: fadeUp 0.4s ease-out;
-  
+
   @keyframes fadeUp {
     0% {
       opacity: 0;
@@ -56,26 +56,26 @@ body {
 } */
 
 @utility btn-primary {
-  @apply transition-transform duration-160 ease-out font-medium px-5 py-3 rounded-full flex gap-1 items-center bg-zinc-900 text-zinc-50 hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-zinc-300 active:scale-[97%] cursor-pointer;
+  @apply flex cursor-pointer items-center gap-1 rounded-full bg-zinc-900 px-5 py-3 font-medium text-zinc-50 transition-transform duration-160 ease-out hover:bg-zinc-700 active:scale-[97%] dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-zinc-300;
 }
 
 @utility btn-secondary {
-  @apply transition-transform duration-160 ease-out font-medium px-5 py-3 rounded-full flex gap-1 items-center border border-zinc-300 text-zinc-950 hover:bg-zinc-200 dark:border-zinc-600 dark:text-zinc-50 dark:hover:bg-zinc-800 active:scale-[97%] cursor-pointer;
+  @apply flex cursor-pointer items-center gap-1 rounded-full border border-zinc-300 px-5 py-3 font-medium text-zinc-950 transition-transform duration-160 ease-out hover:bg-zinc-200 active:scale-[97%] dark:border-zinc-600 dark:text-zinc-50 dark:hover:bg-zinc-800;
 }
 
 @utility btn-ghost {
-  @apply transition-transform duration-160 ease-out font-medium px-5 py-3 rounded-full flex gap-1 items-center text-zinc-950 hover:bg-zinc-200 dark:text-zinc-50 dark:hover:bg-zinc-800 active:scale-[97%] cursor-pointer;
+  @apply flex cursor-pointer items-center gap-1 rounded-full px-5 py-3 font-medium text-zinc-950 transition-transform duration-160 ease-out hover:bg-zinc-200 active:scale-[97%] dark:text-zinc-50 dark:hover:bg-zinc-800;
 }
 
 @utility btn-link {
-  @apply transition-transform duration-160 ease-out font-medium flex gap-2 items-center text-zinc-950 hover:text-zinc-300 dark:text-zinc-50 dark:hover:text-zinc-600 active:scale-[97%] cursor-pointer;
+  @apply flex cursor-pointer items-center gap-2 font-medium text-zinc-950 transition-transform duration-160 ease-out hover:text-zinc-300 active:scale-[97%] dark:text-zinc-50 dark:hover:text-zinc-600;
 }
 
 /* custom CSS */
 
 @keyframes draw {
   to {
-      stroke-dashoffset:0
+    stroke-dashoffset: 0;
   }
 }
 
@@ -88,13 +88,12 @@ svg#logo path {
 
   &:first-child {
     animation-timing-function: ease-in;
-    animation-duration: 1.25s
+    animation-duration: 1.25s;
   }
-  
+
   &:nth-child(2) {
     animation-delay: 1s;
     animation-timing-function: ease-out;
-    animation-duration: 1.5s
+    animation-duration: 1.5s;
   }
 }
-

--- a/app/lib/rate-limit.js
+++ b/app/lib/rate-limit.js
@@ -3,7 +3,10 @@ const MAX_BUCKETS = 10_000;
 const buckets = new Map();
 
 function getClientIp(request) {
-  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const forwardedFor = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")[0]
+    ?.trim();
 
   return (
     request.headers.get("cf-connecting-ip") ||


### PR DESCRIPTION
## Summary
- apply the repository's existing Prettier rules to the files that failed `format:check`
- prevent Dependabot from proposing ESLint 10 until the Next.js lint plugin stack supports it
- preserve the previously merged analytics hardening without behavioral changes

## Verification
- `npm run lint` (passes with one pre-existing `<img>` warning)
- `npm run format:check`
- `npm run build`